### PR TITLE
Fix CWE-79 stored XSS in student list pages and admin notifications

### DIFF
--- a/ContosoUniversity/Scripts/notifications.js
+++ b/ContosoUniversity/Scripts/notifications.js
@@ -2,6 +2,16 @@
 (function() {
     'use strict';
 
+    // HTML-escape untrusted values before inserting them into the DOM (CWE-79).
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     var NotificationSystem = {
         container: null,
         notificationCount: 0,
@@ -79,9 +89,9 @@
             
             notificationEl.innerHTML = 
                 '<button class="notification-close" onclick="NotificationSystem.closeNotification(this)">&times;</button>' +
-                '<div class="notification-title">' + notification.Operation + ' - ' + notification.EntityType + '</div>' +
-                '<div class="notification-message">' + notification.Message + '</div>' +
-                '<div class="notification-time">By ' + notification.CreatedBy + ' • ' + timeAgo + '</div>';
+                '<div class="notification-title">' + escapeHtml(notification.Operation) + ' - ' + escapeHtml(notification.EntityType) + '</div>' +
+                '<div class="notification-message">' + escapeHtml(notification.Message) + '</div>' +
+                '<div class="notification-time">By ' + escapeHtml(notification.CreatedBy) + ' • ' + escapeHtml(timeAgo) + '</div>';
             
             // Add to container
             this.container.appendChild(notificationEl);

--- a/jakarta-ee/student-web-app/WebContent/index.jsp
+++ b/jakarta-ee/student-web-app/WebContent/index.jsp
@@ -1,6 +1,28 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="org.sample.azure.student.coreft.StudentProfile" %>
 <%@ page import="java.util.List" %>
+<%!
+    /* HTML-escape untrusted values to prevent stored XSS (CWE-79). */
+    private static String esc(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String s = String.valueOf(value);
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&': sb.append("&amp;"); break;
+                case '<': sb.append("&lt;"); break;
+                case '>': sb.append("&gt;"); break;
+                case '"': sb.append("&quot;"); break;
+                case '\'': sb.append("&#39;"); break;
+                default: sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+%>
 <html>
 <head>
     <title>Student Management System - Spring Framework 5.3</title>
@@ -39,19 +61,19 @@
         if (error != null) { 
     %>
         <div class="error">
-            <strong>Error:</strong> <%= error %>
+            <strong>Error:</strong> <%= esc(error) %>
         </div>
     <% } %>
     
     <% if (successMessage != null) { %>
         <div class="info">
-            <strong>Success:</strong> <%= successMessage %>
+            <strong>Success:</strong> <%= esc(successMessage) %>
         </div>
     <% } %>
     
     <% if (errorMessage != null) { %>
         <div class="error">
-            <strong>Error:</strong> <%= errorMessage %>
+            <strong>Error:</strong> <%= esc(errorMessage) %>
         </div>
     <% } %>
 
@@ -81,10 +103,10 @@
                     for (StudentProfile student : students) {
             %>
             <tr>
-                <td><%= student.getId() %></td>
-                <td><%= student.getName() %></td>
-                <td><%= student.getEmail() %></td>
-                <td><%= student.getMajor() %></td>
+                <td><%= esc(student.getId()) %></td>
+                <td><%= esc(student.getName()) %></td>
+                <td><%= esc(student.getEmail()) %></td>
+                <td><%= esc(student.getMajor()) %></td>
             </tr>
             <%      }
                 } else { %>

--- a/jakarta-ee/student-web-app/WebContent/spring-index.jsp
+++ b/jakarta-ee/student-web-app/WebContent/spring-index.jsp
@@ -1,6 +1,28 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="org.sample.azure.student.coreft.StudentProfile" %>
 <%@ page import="java.util.List" %>
+<%!
+    /* HTML-escape untrusted values to prevent stored XSS (CWE-79). */
+    private static String esc(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String s = String.valueOf(value);
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&': sb.append("&amp;"); break;
+                case '<': sb.append("&lt;"); break;
+                case '>': sb.append("&gt;"); break;
+                case '"': sb.append("&quot;"); break;
+                case '\'': sb.append("&#39;"); break;
+                default: sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+%>
 <html>
 <head>
     <title>Student Management System - Spring Framework 5.3</title>
@@ -40,19 +62,19 @@
         if (error != null) { 
     %>
         <div class="error">
-            <strong>Error:</strong> <%= error %>
+            <strong>Error:</strong> <%= esc(error) %>
         </div>
     <% } %>
     
     <% if (successMessage != null) { %>
         <div class="info">
-            <strong>Success:</strong> <%= successMessage %>
+            <strong>Success:</strong> <%= esc(successMessage) %>
         </div>
     <% } %>
     
     <% if (errorMessage != null) { %>
         <div class="error">
-            <strong>Error:</strong> <%= errorMessage %>
+            <strong>Error:</strong> <%= esc(errorMessage) %>
         </div>
     <% } %>
 
@@ -80,10 +102,10 @@
                     for (StudentProfile student : students) {
             %>
             <tr>
-                <td><%= student.getId() %></td>
-                <td><%= student.getName() %></td>
-                <td><%= student.getEmail() %></td>
-                <td><%= student.getMajor() %></td>
+                <td><%= esc(student.getId()) %></td>
+                <td><%= esc(student.getName()) %></td>
+                <td><%= esc(student.getEmail()) %></td>
+                <td><%= esc(student.getMajor()) %></td>
             </tr>
             <%      }
                 } else { %>

--- a/jakarta-ee/student-web-app/src/org/sample/azure/student/coreft/StudentProfileListServlet.java
+++ b/jakarta-ee/student-web-app/src/org/sample/azure/student/coreft/StudentProfileListServlet.java
@@ -43,18 +43,18 @@ public class StudentProfileListServlet extends HttpServlet {
                 
                 out.println("<table border='1'><tr><th>ID</th><th>Name</th><th>Email</th><th>Major</th></tr>");
                 for (StudentProfile student : students) {
-                    out.println("<tr><td>" + student.getId() + "</td>" +
-                               "<td>" + student.getName() + "</td>" +
-                               "<td>" + student.getEmail() + "</td>" +
-                               "<td>" + student.getMajor() + "</td></tr>");
+                    out.println("<tr><td>" + escapeHtml(student.getId()) + "</td>" +
+                               "<td>" + escapeHtml(student.getName()) + "</td>" +
+                               "<td>" + escapeHtml(student.getEmail()) + "</td>" +
+                               "<td>" + escapeHtml(student.getMajor()) + "</td></tr>");
                 }
                 out.println("</table>");
                 out.println("<br/><br/><br/>");
-                out.println(objectMapper.writeValueAsString(students));
+                out.println(escapeHtml(objectMapper.writeValueAsString(students)));
                 
             } catch (Exception ex) {
                 logger.error("Error retrieving student list: " + ex.getMessage(), ex);
-                out.println("<p>Error: " + ex.getMessage() + "</p>");
+                out.println("<p>Error: " + escapeHtml(ex.getMessage()) + "</p>");
                 throw new RuntimeException(ex);
             } finally {
                 if (session != null) {
@@ -67,5 +67,26 @@ public class StudentProfileListServlet extends HttpServlet {
             }
             out.println("</body></html>");
         }
+    }
+
+    /** HTML-escape untrusted values to prevent stored XSS (CWE-79). */
+    private static String escapeHtml(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String s = String.valueOf(value);
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&': sb.append("&amp;"); break;
+                case '<': sb.append("&lt;"); break;
+                case '>': sb.append("&gt;"); break;
+                case '"': sb.append("&quot;"); break;
+                case '\'': sb.append("&#39;"); break;
+                default: sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
# Fix CWE-79 (stored XSS) in student list pages and admin notifications

Addresses the CWE-79 findings (rule `d626e486-27bc-48fc-8717-d8af875737de`).

## What was vulnerable
Attacker-controlled student fields (`name`/`email`/`major`) submitted via the add-student forms are persisted and later rendered **unescaped** into HTML, and queued notification fields are written into `innerHTML` without encoding — enabling stored XSS.

## Changes
- `jakarta-ee/student-web-app/WebContent/index.jsp` and `spring-index.jsp`: added an `esc()` helper and HTML-encode all `student.*` fields and status messages rendered via `<%= %>`.
- `jakarta-ee/student-web-app/src/.../StudentProfileListServlet.java`: HTML-encode the student fields, serialized JSON, and exception text written to the response writer (the `/studentProfileList` page cited in the finding's own rationale).
- `ContosoUniversity/Scripts/notifications.js`: added `escapeHtml()` and encode `Operation`/`EntityType`/`Message`/`CreatedBy` before insertion into `innerHTML`.

## Verification
Output-encoding applied at every confirmed HTML sink on the persisted-data path. No behavior change for legitimate (non-markup) values.
